### PR TITLE
Better Log, Provider Server Issues Fixing and Configuration

### DIFF
--- a/src/nPact.Consumer/Rendering/JsonBody.cs
+++ b/src/nPact.Consumer/Rendering/JsonBody.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace nPact.Consumer.Rendering
 {
-    class JsonBody : IJsonable
+    public sealed class JsonBody : IJsonable
     {
         private object body;
 

--- a/src/nPact.Provider.Web/Contracts/ProviderStateSetup.cs
+++ b/src/nPact.Provider.Web/Contracts/ProviderStateSetup.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using nPact.Provider.Web.Setup;
 
@@ -11,7 +14,7 @@ namespace nPact.Provider.Web.Contracts
     /// testing each claim.
     /// Implemantations may inherit from <seealso cref="ProviderStateSetupBase" />.
     /// </summary>
-    public interface IProviderStateSetup
+    public abstract class ProviderStateSetup
     {
         /// <summary>
         /// This method is called before testing each interaction.
@@ -19,12 +22,29 @@ namespace nPact.Provider.Web.Contracts
         /// claims identity (as bearer token).
         /// </summary>
         /// <param name="providerState">The provider state, as defined in the pact interaction.</param>
-        IEnumerable<Claim> GetClaims(string providerState);
+        public virtual IEnumerable<Claim> GetClaims(string providerState)
+            => default;
+
         /// <summary>
         /// This method is called before testing each interaction.
         /// It should setup the service collection (i.e. mock) with services.
         /// </summary>
         /// <param name="providerState">The provider state, as defined in the pact interaction.</param>
-        Action<IServiceCollection> ConfigureServices(string providerState);
+        public virtual Action<IServiceCollection> ConfigureServices(string providerState)
+            => default;
+
+        /// <summary>
+        /// This method is called before testing each interaction.
+        /// It should setup de application
+        /// </summary>
+        public virtual Action<IApplicationBuilder> Configure()
+            => default;
+
+        /// <summary>
+        /// This method is called before testing each interaction.
+        /// It should setup de application configuration
+        /// </summary>
+        public virtual Action<WebHostBuilderContext, IConfigurationBuilder> ConfigureAppConfig()
+            => default;
     }
 }

--- a/src/nPact.Provider.Web/PactRunner.cs
+++ b/src/nPact.Provider.Web/PactRunner.cs
@@ -23,12 +23,12 @@ namespace nPact.Provider.Web
     public class PactRunner<TStartup> where TStartup : class
     {
         private readonly IProviderConfiguration configuration;
-        private readonly IProviderStateSetup setup;
+        private readonly ProviderStateSetup setup;
         /// <summary>
         /// Creates a new wrapper object to setup a test server and fetch all pacts. Configuration is read solely from environment variables.
         /// </summary>
         /// <param name="setup">A setup object responsible for mocking in front of each verification.</param>
-        public PactRunner(IProviderStateSetup setup) : this(null, setup)
+        public PactRunner(ProviderStateSetup setup) : this(null, setup)
         {
         }
         /// <summary>
@@ -36,7 +36,7 @@ namespace nPact.Provider.Web
         /// </summary>
         /// <param name="configuration"> A configuration object</param>
         /// <param name="setup">A setup object responsible for mocking in front of each verification.</param>
-        public PactRunner(IProviderConfiguration configuration, IProviderStateSetup setup)
+        public PactRunner(IProviderConfiguration configuration, ProviderStateSetup setup)
         {
             this.setup = setup;
             this.configuration = configuration ?? new EnvironmentBasedConfiguration();

--- a/src/nPact.Provider.Web/Setup/ProviderStateSetupBase.cs
+++ b/src/nPact.Provider.Web/Setup/ProviderStateSetupBase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Reflection;
-using nPact.Provider.Web.Config;
 using Microsoft.Extensions.DependencyInjection;
 using nPact.Common.Contracts;
 using nPact.Common.Extensions;
@@ -11,10 +10,10 @@ using nPact.Provider.Web.Contracts;
 
 namespace nPact.Provider.Web.Setup
 {
-    public abstract class ProviderStateSetupBase : IProviderStateSetup
+    public abstract class ProviderStateSetupBase : ProviderStateSetup
     {
         protected IProviderConfiguration Configuration { get; set; } 
-        public virtual Action<IServiceCollection> ConfigureServices(string providerState)
+        public override Action<IServiceCollection> ConfigureServices(string providerState)
         {
             var allMethods = GetMethods(providerState);
             var callBacks = allMethods
@@ -36,7 +35,7 @@ namespace nPact.Provider.Web.Setup
                 }
             };
         }
-        public virtual IEnumerable<Claim> GetClaims(string providerState) =>
+        public override IEnumerable<Claim> GetClaims(string providerState) =>
              GetMethods(providerState).Where(IsClaimsMethod).SelectMany(m => (IEnumerable<Claim>) m.Invoke(this,new object[]{} ));
 
         private IEnumerable<MethodInfo> GetMethods(string key) => 

--- a/src/nPact.Provider.Web/nPact.Provider.Web.csproj
+++ b/src/nPact.Provider.Web/nPact.Provider.Web.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="Microsoft.Aspnetcore.Testhost" Version="3.1.7" />
@@ -17,7 +18,7 @@
     <Description>A helper library for implementing Pact tests using nPact.Provider package</Description>
     <Company />
     <Product>nPact</Product>
-    <PackageVersion>0.1.0.0-beta</PackageVersion>
+    <PackageVersion>0.1.1.3-beta</PackageVersion>
     <Authors>Øyvind Skaar, Rodrigo Ramos</Authors>
     <Copyright>Rodrigo Ramos</Copyright>
     <PackageProjectUrl>https://github.com/rodrigoramos/nPact</PackageProjectUrl>

--- a/src/nPact.Provider/HttpClientWrapper.cs
+++ b/src/nPact.Provider/HttpClientWrapper.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace nPact.Provider
+{
+    public class HttpClientWrapper
+    {
+        private readonly HttpClient _httpClient;
+
+        protected HttpClientWrapper()
+        {
+        }
+
+        public HttpClientWrapper(HttpClient httpClient)
+            : this()
+            => _httpClient = httpClient;
+
+        public virtual async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+            => await _httpClient.SendAsync(request);
+    }
+}

--- a/src/nPact.Provider/Model/Interaction.cs
+++ b/src/nPact.Provider/Model/Interaction.cs
@@ -1,16 +1,16 @@
 using System;
-using nPact.Common.Contracts;
 using Newtonsoft.Json;
+using nPact.Common.Contracts;
 
 namespace nPact.Provider.Model
 {
-    class Interaction : IPactInformation
+    public class Interaction : IPactInformation
     {
         public string Description { get; set; }
         [JsonProperty("provider_state")]
         public string ProviderState { get; set; }
-        public Request Request { get; set; }
-        public Response Response { get; set; }
+        public virtual Request Request { get; set; }
+        public virtual Response Response { get; set; }
         public string Consumer { get; set; }
         public DateTime Created { get; set; }
     }

--- a/src/nPact.Provider/Model/Response.cs
+++ b/src/nPact.Provider/Model/Response.cs
@@ -3,7 +3,7 @@ using System.Net;
 
 namespace nPact.Provider.Model
 {
-    class Response
+    public class Response
     {
         public HttpStatusCode Status { get; set; }
         public IDictionary<string, string> Headers { get; set; }

--- a/src/nPact.Provider/Model/Result.cs
+++ b/src/nPact.Provider/Model/Result.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
 using nPact.Common.Contracts;
 using nPact.Provider.Contracts;
 
@@ -16,9 +18,11 @@ namespace nPact.Provider.Model
         {
             this.expected = expected;
         }
+
         public Result(string title, IPactInformation info, ValidationTypes types, params string[] errors)
         {
-            this.errors = errors.ToList(); ;
+            this.errors = errors.ToList();
+            ;
             ErrorTypes = types;
             Title = title;
             Description = info.Description;
@@ -47,6 +51,7 @@ namespace nPact.Provider.Model
                 }
             }
         }
+
         public void Add(HttpResponseMessage response)
         {
             ActualResponse = response;
@@ -65,13 +70,55 @@ namespace nPact.Provider.Model
 
         public string ProviderState { get; }
 
-        public override string ToString() => Success ? $"Ok ({Title})" : 
-            string.Concat(
+        public override string ToString()
+        {
+            if (Success)
+                return $"Ok ({Title})";
+
+            var actualResponseLogTask = LogActualResponse(ActualResponse);
+            actualResponseLogTask.Wait();
+
+            return string.Concat(
                 $"Validation has failed for {Title} from {Consumer}:",
                 Environment.NewLine,
                 new string('-', 3),
                 Environment.NewLine,
-                string.Join(Environment.NewLine, errors));
+                string.Join(Environment.NewLine, errors),
+                Environment.NewLine,
+                new string('-', 3),
+                Environment.NewLine,
+                actualResponseLogTask.Result,
+                new string('-', 3),
+                Environment.NewLine,
+                LogExpectedResponse(expected),
+                Environment.NewLine
+            );
+        }
 
+        private static async Task<string> LogActualResponse(HttpResponseMessage responseMessage)
+        {
+            return new StringBuilder($"Actual Response{Environment.NewLine}")
+                .Append("Status Code: ").AppendLine(responseMessage.StatusCode.ToString())
+                .Append("Reason Phrase: ").AppendLine(responseMessage.ReasonPhrase)
+                .AppendLine("Headers").Append(responseMessage.Headers)
+                .Append(responseMessage.Content.Headers.ToString())
+                .Append("Content: ").AppendLine(await responseMessage.Content.ReadAsStringAsync())
+                .ToString();
+        }
+
+        private static string LogExpectedResponse(Response expectedResponse)
+        {
+            Func<IDictionary<string, string>, string> printDictionary = dict =>
+                (!dict.Any()
+                    ? string.Empty
+                    : dict.Select(x => $"{x.Key}: {x.Value}")
+                        .Aggregate((f, s) => $"{f}{Environment.NewLine}{s}"));
+
+            return new StringBuilder($"Expected Response{Environment.NewLine}")
+                .Append("Status Code: ").AppendLine(expectedResponse.Status.ToString())
+                .AppendLine("Headers").AppendLine(printDictionary(expectedResponse.Headers))
+                .Append("Content: ").AppendLine(expectedResponse.Body?.ToString())
+                .ToString();
+        }
     }
 }

--- a/src/nPact.Provider/Model/Result.cs
+++ b/src/nPact.Provider/Model/Result.cs
@@ -22,7 +22,6 @@ namespace nPact.Provider.Model
         public Result(string title, IPactInformation info, ValidationTypes types, params string[] errors)
         {
             this.errors = errors.ToList();
-            ;
             ErrorTypes = types;
             Title = title;
             Description = info.Description;

--- a/src/nPact.Provider/nPact.Provider.csproj
+++ b/src/nPact.Provider/nPact.Provider.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Title>nPact Provider Test tool</Title>
     <Description>A library for implementing Pact provider tests</Description>
-    <PackageVersion>0.1.0.0-beta</PackageVersion>
+    <PackageVersion>0.1.0.1-beta</PackageVersion>
     <Authors>Øyvind Skaar, Rodrigo Ramos</Authors>
     <Copyright>Rodrigo Ramos</Copyright>
     <PackageProjectUrl>https://github.com/rodrigoramos/nPact</PackageProjectUrl>

--- a/src/nPact.Provider/nPact.Provider.csproj.DotSettings
+++ b/src/nPact.Provider/nPact.Provider.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=model/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/nPact.Consumer.Tests/Rendering/JsonBodyTests.cs
+++ b/tests/nPact.Consumer.Tests/Rendering/JsonBodyTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json.Linq;
+using nPact.Common.Contracts;
+using nPact.Consumer.Rendering;
+using Xunit;
+
+namespace nPact.Consumer.Tests.Rendering
+{
+    public class JsonBodyTests
+    {
+        [Fact]
+        public void RenderWithoutBody_ShouldReturnNull()
+        {
+            var jBody = new JsonBody(null);
+            jBody.Render().Should().BeNull();
+        }
+
+        [Fact]
+        public void RenderWithIJsonable_ShouldCallRenderMethodOfBody()
+        {
+            var iJsonableMock = new Mock<IJsonable>();
+            var jBody = new JsonBody(iJsonableMock.Object);
+
+            jBody.Render();
+
+            iJsonableMock.Verify(x => x.Render(), Times.Once());
+        }
+
+        [Fact]
+        public void RenderWithString_ShouldParseAsJsonObject()
+        {
+            var jsonObjectString = @"{ prop1: 'value' }";
+            var jBody = new JsonBody(jsonObjectString);
+
+            jBody.Render()
+                .Should()
+                    .BeOfType<JObject>()
+                .Which
+                    .GetValue("prop1").Value<string>().Should().Be("value");
+
+        }
+
+        [Fact]
+        public void RenderWithArray_ShouldParseAsJArrayObject()
+        {
+            var bodyArray = new[] { "value1", "value2" };
+            var jBody = new JsonBody(bodyArray);
+
+            jBody.Render()
+                .Should()
+                    .BeOfType<JArray>()
+                .Which
+                    .Count.Should().Be(bodyArray.Length);
+
+        }
+
+        [Fact]
+        public void RenderWithObject_ShouldCreateAJObject() 
+        {
+            var jObject = new { prop1 = "value1" };
+            var jBody = new JsonBody(jObject);
+
+            jBody.Render()
+                .Should()
+                    .BeOfType<JObject>()
+                .Which
+                    .GetValue("prop1").Value<string>().Should().Be("value1");
+        }
+    }
+}

--- a/tests/nPact.Consumer.Tests/nPact.Consumer.Tests.csproj
+++ b/tests/nPact.Consumer.Tests/nPact.Consumer.Tests.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.json" Version="12.0.3" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/nPact.Provider.Tests/Model/InteractionPactTests.cs
+++ b/tests/nPact.Provider.Tests/Model/InteractionPactTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json.Linq;
+using nPact.Common.Contracts;
+using nPact.Provider.Model;
+using Xunit;
+
+namespace nPact.Provider.Tests.Model
+{
+    public class InteractionPactTests
+    {
+        private string resultMessage;
+        
+        public InteractionPactTests()
+        {
+            var interactionPactMock = new Mock<Interaction>();
+
+            interactionPactMock.SetupGet(x => x.Request)
+                .Returns(new Request
+                {
+                    Method = "Get",
+                    Headers = new Dictionary<string, string>(),
+                    Path = "/"
+                });
+
+            interactionPactMock.Setup(x => x.Response)
+                .Returns(new Response
+                {
+                    Status = HttpStatusCode.OK,
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"content-type", "application/json; "}
+                    },
+                    Body = JObject.Parse("{ a: 'b'}")
+                });
+
+            var providerConfigMock = new Mock<IProviderConfiguration>();
+            var httpClient = new Mock<HttpClientWrapper>();
+            httpClient.Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("{ a: 'b' }", Encoding.UTF8, "application/json"),
+                });
+
+            var sut = new InteractionPact(interactionPactMock.Object, providerConfigMock.Object,null);
+            var resultTask = sut.Verify(httpClient.Object);
+            resultTask.Wait();
+            resultMessage = resultTask.Result.ToString();
+        }
+        
+        [Fact]
+        public void LogStatusCode() => resultMessage.Should().Contain("Status code was Unauthorized. Expected OK");
+
+        [Fact]
+        public void LogActualMessage() =>
+            resultMessage.Should().Contain(@"Actual Response
+Status Code: Unauthorized
+Reason Phrase: Unauthorized
+Headers
+Content-Type: application/json; charset=utf-8");
+
+        [Fact]
+        public void LogActualMessageLog() 
+            => resultMessage.Should().Contain("Content: { a: 'b' }");
+
+        [Fact]
+        public void LogExpectedMessageLog() =>
+            resultMessage.Should().Contain(@"Expected Response
+Status Code: OK
+Headers
+content-type: application/json; 
+Content: {
+  ""a"": ""b""
+}");
+    }
+}

--- a/tests/nPact.Provider.Tests/Model/RequestTest.cs
+++ b/tests/nPact.Provider.Tests/Model/RequestTest.cs
@@ -48,7 +48,7 @@ namespace nPact.Provider.Tests.Model
                 {
                     {"content-type", "application/json; charset=utf-8"},
                     {"X-Correlation-ID", System.Guid.NewGuid().ToString()},
-                    {"__ABC_ANTI_CSRF_LOGIN__", "312.123.123-12"}
+                    {"__HEADER_WITH_ALOT_UNDERSCORE__", "value-12"}
                 },
                 Body = JObject.Parse(json)
             };

--- a/tests/nPact.Provider.Tests/Model/RequestTest.cs
+++ b/tests/nPact.Provider.Tests/Model/RequestTest.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using nPact.Provider.Model;
+using Xunit;
+
+namespace nPact.Provider.Tests.Model
+{
+    public class RequestTest
+    {
+        // TODO: Criar testes em questão de case para Headers
+        // TODO: Corrigir e implementar separação de cabeçalhos para o conteúdo e para a request
+        [Fact]
+        public void RequestWithContentTypeJson()
+        {
+            const string json = @"{ 'id': 99, 'name': 'Willian Knickersen' }";
+
+            var request = new Request
+            {
+                Method = "GET",
+                Path = "/uri-fortest",
+                Headers = new Dictionary<string, string>
+                {
+                    {"content-type", "application/json; charset=utf-8"}
+                },
+                Body = JObject.Parse(json)
+            };
+
+            var message = request.BuildMessage();
+
+            message.Content.Headers.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            {
+                {"Content-Type", new[] {"application/json; charset=utf-8"}}
+            });
+        }
+
+
+        [Fact]
+        public void RequestWithCustomHeaders()
+        {
+            const string json = @"{ 'id': 99, 'name': 'Willian Knickersen' }";
+
+            var request = new Request
+            {
+                Method = "GET",
+                Path = "/uri-fortest",
+                Headers = new Dictionary<string, string>
+                {
+                    {"content-type", "application/json; charset=utf-8"},
+                    {"X-Correlation-ID", System.Guid.NewGuid().ToString()},
+                    {"__ABC_ANTI_CSRF_LOGIN__", "312.123.123-12"}
+                },
+                Body = JObject.Parse(json)
+            };
+
+            var message = request.BuildMessage();
+
+            message.Content.Headers.Should().BeEquivalentTo(new Dictionary<string, string[]>
+            {
+                {"Content-Type", new[] {"application/json; charset=utf-8"}}
+            });
+        }
+    }
+}

--- a/tests/nPact.Provider.Tests/nPact.Provider.Tests.csproj
+++ b/tests/nPact.Provider.Tests/nPact.Provider.Tests.csproj
@@ -6,7 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions.Web" Version="1.0.125" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
- Test Services can now be registered in the Provider Server using ProviderState
- ProviderState is abstract class instead of interface
- It's possible to override Config file of Provider Server (appsetttings)
- Fix header issue
- Log message when test failed now shows Actual Response e Expected Response (Status Code, Headers and Content);
- More Unit Tests